### PR TITLE
Update README for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# NixVim Configuration
+
+This repository contains my [NixVim](https://github.com/nix-community/nixvim) configuration. It is provided as a [Nix](https://nixos.org/) flake that can be run directly or included in your system configuration.
+
+## Usage
+
+### Run with `nix run`
+
+Use `nix run` to start Neovim using this configuration without installing anything globally:
+
+```bash
+nix run github:USERNAME/velovim
+```
+
+Replace the flake URL with your desired reference (for example `.` if you cloned the repository).
+
+### Home Manager Module
+
+The flake exposes a Home Manager module. Import it and enable `velovim` in your `home.nix`:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [ inputs.velovim.homeModules.default ];
+
+  velovim.enable = true;
+}
+```
+
+Apply the changes with `home-manager switch`.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,0 @@
-#+TITLE: NixVim Configuration
-
-This repository contains my [NixVim](https://github.com/nix-community/nixvim)
-configuration. The setup is packaged as a Nix flake and can be run or
-installed with the [Nix](https://nixos.org/) package manager.


### PR DESCRIPTION
## Summary
- switch to Markdown README
- document running via `nix run`
- describe how to enable as a Home Manager module

## Testing
- `nix flake check --no-build --print-build-logs` *(fails: `command not found: nix`)*

------
https://chatgpt.com/codex/tasks/task_e_68711b97675c832cbc47a04a1bf93aa3